### PR TITLE
recipes-kernel: Load multimedia related modules automatically

### DIFF
--- a/meta-rcar-gen3/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bb
+++ b/meta-rcar-gen3/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bb
@@ -70,6 +70,9 @@ PACKAGES = "\
 
 FILES_${PN} = " \
     /lib/modules/${KERNEL_VERSION}/extra/mmngr.ko \
+    ${sysconfdir}/modules-load.d \
 "
 
 RPROVIDES_${PN} += "kernel-module-mmngr"
+
+KERNEL_MODULE_AUTOLOAD_append = " mmngr"

--- a/meta-rcar-gen3/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bb
+++ b/meta-rcar-gen3/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bb
@@ -55,6 +55,9 @@ PACKAGES = "\
 
 FILES_${PN} = " \
     /lib/modules/${KERNEL_VERSION}/extra/mmngrbuf.ko \
+    ${sysconfdir}/modules-load.d \
 "
 
 RPROVIDES_${PN} += "kernel-module-mmngrbuf"
+
+KERNEL_MODULE_AUTOLOAD_append = " mmngrbuf"

--- a/meta-rcar-gen3/recipes-kernel/kernel-module-uvcs/kernel-module-uvcs-drv.bb
+++ b/meta-rcar-gen3/recipes-kernel/kernel-module-uvcs/kernel-module-uvcs-drv.bb
@@ -68,3 +68,10 @@ PACKAGES = " \
 FILES_${PN}-sstate = " \
     ${includedir}/uvcs_ioctl.h \
 "
+
+FILES_${PN} = " \
+    /lib/modules/${KERNEL_VERSION}/extra/uvcs_drv.ko \
+    ${sysconfdir}/modules-load.d \
+"
+
+KERNEL_MODULE_AUTOLOAD_append = " uvcs_drv"

--- a/meta-rcar-gen3/recipes-kernel/kernel-module-vspmif/kernel-module-vspmif.bb
+++ b/meta-rcar-gen3/recipes-kernel/kernel-module-vspmif/kernel-module-vspmif.bb
@@ -62,6 +62,9 @@ PACKAGES = "\
 
 FILES_${PN} = " \
     /lib/modules/${KERNEL_VERSION}/extra/vspm_if.ko \
+    ${sysconfdir}/modules-load.d \
 "
 
 RPROVIDES_${PN} += "kernel-module-vspmif kernel-module-vspm-if"
+
+KERNEL_MODULE_AUTOLOAD_append = " vspm_if"


### PR DESCRIPTION
Which is equivalent to the following command:
modprobe -a mmngr mmngrbuf vspm_if uvcs_drv

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>