### PR TITLE
Change Weston repaint window

### DIFF
--- a/meta-rcar-gen3/recipes-graphics/wayland/weston-init/weston.ini
+++ b/meta-rcar-gen3/recipes-graphics/wayland/weston-init/weston.ini
@@ -1,2 +1,2 @@
 [core]
-repaint-window=34
+repaint-window=8


### PR DESCRIPTION
repaint-window is used to set the approximate
length of the repaint window in milliseconds.
The repaint window is used to control and reduce
the output latency for clients. To achieve 60 fps
we need to keep repaint-window less than 16. The
new value 8 was received empirically with respect
to best performance and frame.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>